### PR TITLE
update yepnope license info in package.json

### DIFF
--- a/ajax/libs/yepnope/package.json
+++ b/ajax/libs/yepnope/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/SlexAxton/yepnope.js"
   },
   "license": {
-    "type": "New BSD",
+    "type": "BSD-3-Clause",
     "url": "https://github.com/SlexAxton/yepnope.js/blob/master/LICENSE.md"
   },
   "author": "Alex Sexton, Ralph Holzmann"


### PR DESCRIPTION
Update it because the license's type yepnope used has changed. CC#11931
Ref: https://github.com/SlexAxton/yepnope.js/blob/master/LICENSE.md