### PR TITLE
Update Vague.js license info in package.json

### DIFF
--- a/ajax/libs/Vague.js/package.json
+++ b/ajax/libs/Vague.js/package.json
@@ -10,6 +10,11 @@
     "blur",
     "filter"
   ],
+  "license":{
+    "type": "MIT",
+    "url": "https://cdnjs.cloudflare.com/ajax/libs/Vague.js/0.0.6/Vague.js"
+
+  }
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/GianlucaGuarini/Vague.js.git",


### PR DESCRIPTION
Update it because the license's info is missing CC#11931
Ref: https://cdnjs.cloudflare.com/ajax/libs/Vague.js/0.0.6/Vague.js
